### PR TITLE
Multiple file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ You can also rename image files:
     $ imagehash image.jpg --rename
     image.jpg -> 1a787a7a60727a7f.jpg
 
+Rename multiple files to their hashes (quick way to remove duplicates):
+
+    $ imagehash image1.jpg image2.jpg image3.jpg --rename
+
 Rename all `jpg` files in a directory (incl. subdirectories) to their hashes:
 
     $ find . -name '*jpg' -execdir imagehash {} --rename \;

--- a/imagehash_cli/cli.py
+++ b/imagehash_cli/cli.py
@@ -37,6 +37,7 @@ def get_hash(img, hash_type='average'):
 
 
 def process_file(orig_path, hash, rename, template, dry_run):
+    """ Process a single file """
     try:
         img = Image.open(orig_path)
     except IOError:

--- a/imagehash_cli/cli.py
+++ b/imagehash_cli/cli.py
@@ -65,11 +65,11 @@ def main(hash, rename, dry_run, template, image):
     if rename:
         new_name = get_new_name(orig_path, hash_string, template)
         click.echo('%s -> %s' % (orig_path, new_name), err=True)
-        try:
-            if not dry_run:
+        if not dry_run:
+            try:
                 os.rename(orig_path, new_name)
-        except OSError:
-            raise click.FileError(orig_path)
+            except OSError:
+                raise click.FileError(new_name)
     else:
         click.echo(hash_string, nl=False)
 

--- a/imagehash_cli/cli.py
+++ b/imagehash_cli/cli.py
@@ -27,7 +27,7 @@ def get_new_name(orig_path, hash, template=None):
     return new_name
 
 
-def get_hash(img, hash_type):
+def get_hash(img, hash_type='average'):
     """ Returns hash of the PIL image """
     if hash_type in HASH_FUNCTIONS:
         hash = str(HASH_FUNCTIONS[hash_type](img))
@@ -36,26 +36,7 @@ def get_hash(img, hash_type):
     return str(hash)
 
 
-@click.command()
-@click.option(
-    '--hash',
-    type=click.Choice(HASH_FUNCTIONS.keys()),
-    default='average'
-)
-@click.option('--rename', is_flag=True)
-@click.option('--dry-run', is_flag=True)
-@click.option(
-    '--template',
-    default=None,
-    help='Template for rename (e.g. {path}/{hash}{ext})'
-)
-@click.argument('image',
-                type=click.Path(exists=True),
-                required=True)
-def main(hash, rename, dry_run, template, image):
-    """Command Line Image Hash"""
-    orig_path = image
-
+def process_file(orig_path, hash, rename, template, dry_run):
     try:
         img = Image.open(orig_path)
     except IOError:
@@ -70,7 +51,48 @@ def main(hash, rename, dry_run, template, image):
                 os.rename(orig_path, new_name)
             except OSError:
                 raise click.FileError(new_name)
-    else:
-        click.echo(hash_string, nl=False)
 
     return hash_string
+
+
+@click.command()
+@click.pass_context
+@click.option(
+    '--hash',
+    type=click.Choice(HASH_FUNCTIONS.keys()),
+    default='average'
+)
+@click.option('--rename', is_flag=True)
+@click.option('--dry-run', is_flag=True)
+@click.option(
+    '--template',
+    default=None,
+    help='Template for rename (e.g. {path}/{hash}{ext})'
+)
+@click.argument(
+    'image',
+    type=click.Path(exists=True),
+    nargs=-1,
+    required=True
+)
+def main(ctx, hash, rename, dry_run, template, image):
+    """Command Line Image Hash"""
+
+    if len(image) == 1:
+        # if one image provided, read it
+        orig_path = image[0]
+        response = process_file(orig_path, hash, rename, template, dry_run)
+        if not rename:
+            click.echo(response, nl=False)
+        return
+
+    else:
+        # if multiple images provided, go one by one
+        responses = []
+        for path in image:
+            file_hash = process_file(path, hash, rename, template, dry_run)
+            responses.append('%s %s' % (path, file_hash))
+        response = os.linesep.join(responses)
+        if not rename:
+            click.echo(response, nl=False)
+        return response

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ import click
 from click.testing import CliRunner
 from imagehash_cli import cli
 from PIL import Image
+import random
 import os
 
 
@@ -13,7 +14,14 @@ def runner():
 
 @pytest.fixture
 def image():
-    img = Image.new('RGB', (255, 255))
+    # TODO: not good to introduce random numbers in test
+    # but it saves us from all black images
+    color = (
+        random.randint(0, 255),
+        random.randint(0, 255),
+        random.randint(0, 255)
+    )
+    img = Image.new('RGB', (255, 255), color=color)
     return img
 
 
@@ -25,7 +33,7 @@ def test_get_hash(image):
     hash_functions = cli.HASH_FUNCTIONS
     for key in hash_functions:
         hash_function = hash_functions[key]
-        hash = cli.get_hash(image, 'average')
+        hash = cli.get_hash(image, key)
         assert type(hash) == str
         assert hash == str(hash_function(image))
     try:
@@ -64,7 +72,14 @@ def test_rename_with_template():
 
 
 def test_cli(runner):
+    # Executed, but no stream
     result = runner.invoke(cli.main)
+    assert result.exception
+
+
+def test_cli_no_image(runner):
+    # Executed, but no stream
+    result = runner.invoke(cli.main, [])
     assert result.exception
 
 
@@ -98,18 +113,47 @@ def test_cli_missing_file(runner):
         assert result.exception
 
 
-def test_cli_file_hash(runner, image):
-    filename = '/tmp/test.jpg'
-    hash_functions = cli.HASH_FUNCTIONS
-    if os.path.exists(filename):
-        os.remove(filename)
+def test_cli_multiple(runner, image):
+    num_images = 5
+    filenames = ['/tmp/test-%d.jpg' % (n) for n in range(num_images)]
+    imghash = cli.get_hash(image)
     with runner.isolated_filesystem():
-        image.save(filename, format='JPEG')
-        for h in hash_functions.keys():
-            imghash = cli.get_hash(image, h)
-            result = runner.invoke(cli.main, [filename, '--hash', h])
-            assert result.exit_code == 0
-            assert result.output == imghash
+        for path in filenames:
+            if os.path.exists(path):
+                os.remove(path)
+            image.save(path, format='JPEG')
+        result = runner.invoke(cli.main, filenames)
+        assert result.exit_code == 0
+        expected_output = os.linesep.join([
+            '%s %s' % (path, imghash) for path in filenames
+        ])
+        assert result.output == expected_output
+        # clean up
+        for path in filenames:
+            os.remove(path)
+
+
+def test_cli_multiple_rename(runner, image):
+    num_images = 5
+    filenames = ['/tmp/test-%d.jpg' % (n) for n in range(num_images)]
+    imghash = cli.get_hash(image)
+    with runner.isolated_filesystem():
+        for path in filenames:
+            if os.path.exists(path):
+                os.remove(path)
+            image.save(path, format='JPEG')
+        result = runner.invoke(cli.main, filenames+['--rename'])
+        assert result.exit_code == 0
+        for path in filenames:
+            new_name = cli.get_new_name(path, imghash)
+            assert os.path.exists(new_name)
+            assert not os.path.exists(path)
+        # clean up
+        for path in filenames:
+            new_name = cli.get_new_name(path, imghash)
+            # hashes might be the same
+            if os.path.exists(new_name):
+                os.remove(new_name)
 
 
 def test_cli_file_rename(runner, image):

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist=py27, py35, flake8
 
 [testenv]
-commands=py.test --cov imagehash_cli {posargs}
+commands=py.test --cov imagehash_cli --cov-report=term-missing {posargs}
 setenv=
     LC_ALL=de_DE.utf-8
     LANG=de_DE.utf-8


### PR DESCRIPTION
Can now pass multiple files as parameters. The behavior is slightly different. Instead of printing the hash, it will print filenames and hashes, one pair per line.

