### PR TITLE
Make it easier to machine-process output

### DIFF
--- a/imagehash_cli/cli.py
+++ b/imagehash_cli/cli.py
@@ -78,22 +78,11 @@ def process_file(orig_path, hash, rename, template, dry_run):
 )
 def main(ctx, hash, rename, dry_run, template, image):
     """Command Line Image Hash"""
-
-    if len(image) == 1:
-        # if one image provided, read it
-        orig_path = image[0]
-        response = process_file(orig_path, hash, rename, template, dry_run)
-        if not rename:
-            click.echo(response)
-        return
-
-    else:
-        # if multiple images provided, go one by one
-        responses = []
-        for path in image:
-            file_hash = process_file(path, hash, rename, template, dry_run)
-            responses.append('%s %s' % (path, file_hash))
-        response = os.linesep.join(responses)
-        if not rename:
-            click.echo(response)
-        return response
+    responses = []
+    for path in image:
+        file_hash = process_file(path, hash, rename, template, dry_run)
+        responses.append('%s %s' % (path, file_hash))
+    response = os.linesep.join(responses)
+    if not rename:
+        click.echo(response)
+    return response

--- a/imagehash_cli/cli.py
+++ b/imagehash_cli/cli.py
@@ -81,5 +81,5 @@ def main(ctx, hash, rename, dry_run, template, image):
     for path in image:
         file_hash = process_file(path, hash, rename, template, dry_run)
         if not rename:
-            out = '%s\t%s' % (path, file_hash)
+            out = '%s\t%s' % (file_hash, path)
             click.echo(out)

--- a/imagehash_cli/cli.py
+++ b/imagehash_cli/cli.py
@@ -78,11 +78,8 @@ def process_file(orig_path, hash, rename, template, dry_run):
 )
 def main(ctx, hash, rename, dry_run, template, image):
     """Command Line Image Hash"""
-    responses = []
     for path in image:
         file_hash = process_file(path, hash, rename, template, dry_run)
-        responses.append('%s %s' % (path, file_hash))
-    response = os.linesep.join(responses)
-    if not rename:
-        click.echo(response)
-    return response
+        if not rename:
+            out = '%s %s' % (path, file_hash)
+            click.echo(out)

--- a/imagehash_cli/cli.py
+++ b/imagehash_cli/cli.py
@@ -84,7 +84,7 @@ def main(ctx, hash, rename, dry_run, template, image):
         orig_path = image[0]
         response = process_file(orig_path, hash, rename, template, dry_run)
         if not rename:
-            click.echo(response, nl=False)
+            click.echo(response)
         return
 
     else:
@@ -95,5 +95,5 @@ def main(ctx, hash, rename, dry_run, template, image):
             responses.append('%s %s' % (path, file_hash))
         response = os.linesep.join(responses)
         if not rename:
-            click.echo(response, nl=False)
+            click.echo(response)
         return response

--- a/imagehash_cli/cli.py
+++ b/imagehash_cli/cli.py
@@ -81,5 +81,5 @@ def main(ctx, hash, rename, dry_run, template, image):
     for path in image:
         file_hash = process_file(path, hash, rename, template, dry_run)
         if not rename:
-            out = '%s %s' % (path, file_hash)
+            out = '%s\t%s' % (path, file_hash)
             click.echo(out)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27, py35, flake8
+envlist=py27, py35, py36, flake8
 
 [testenv]
 commands=py.test --cov imagehash_cli --cov-report=term-missing {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,7 @@ envlist=py27, py35, py36, flake8
 
 [testenv]
 commands=py.test --cov imagehash_cli --cov-report=term-missing {posargs}
-setenv=
-    LC_ALL=de_DE.utf-8
-    LANG=de_DE.utf-8
+passenv=LC_ALL LANG
 deps=
     pytest
     pytest-cov


### PR DESCRIPTION
Hi. I don't know if imagehash-cli is maintained, but I found it via pip search and had a need for it.

I needed to process the output and some inconsistencies got in the way. This changes the output format in various ways to make it easier to use in a pipeline. It prints hashes and input paths as tab-separated columns, unifies the single and multi-file output formats, and prints hashes as they are generated. The rationale for each case is in the commit message details below.